### PR TITLE
cloud-init kernels do not have batman-adv installed

### DIFF
--- a/playbooks/roles/ff.mesh_batman/handlers/main.yml
+++ b/playbooks/roles/ff.mesh_batman/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: update_initramfs
+  command: update-initramfs -u
+
+- name: update_grub
+  command: update-grub
+
+- name: post_reboot_tasks
+  debug:
+    msg: "System has rebooted successfully after kernel changes."

--- a/playbooks/roles/ff.mesh_batman/tasks/batctl_from_repo.yml
+++ b/playbooks/roles/ff.mesh_batman/tasks/batctl_from_repo.yml
@@ -1,0 +1,34 @@
+---
+
+- name: Check if a cloud-init variant kernel is installed
+  shell: |
+    uname -r | grep -q "cloud"
+  register: cloud_kernel_installed
+  failed_when: false
+
+- name: Install regular linux-image-amd64 kernel if cloud-init variant is installed
+  apt:
+    name: linux-image-amd64
+    state: present
+  when: cloud_kernel_installed.rc == 0
+  notify:
+    - update_initramfs
+    - update_grub
+
+- name: Purge all cloud-init variant kernels if installed
+  apt:
+    name: "linux-image-*-cloud-amd64"
+    state: absent
+    purge: yes
+  when: cloud_kernel_installed.rc == 0
+
+- name: Reboot the server if kernel changes have been made
+  reboot:
+    msg: "Rebooting to apply new kernel"
+    pre_reboot_delay: 10
+  when: cloud_kernel_installed.rc == 0
+  notify:
+    - post_reboot_tasks
+
+- name: Install batctl from repo
+  apt: name=batctl

--- a/playbooks/roles/ff.mesh_batman/tasks/main.yml
+++ b/playbooks/roles/ff.mesh_batman/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
-
 - name: Include 'Build from source'
   include_tasks: build_from_source.yml
   when: batman_build_from_source
 
-- name: Install batctl
-  apt: name=batctl
+- name: Install batctl from repo - switch kernel if needed
+  include_tasks: build_from_repo.yml
   when: not batman_build_from_source
 
 - name: Install autostart batman_adv on boot
@@ -13,3 +12,10 @@
 
 - name: Load batman_adv module
   modprobe: name=batman_adv state=present
+
+
+### uninstall cloud-init and install real image:
+#sudo apt install linux-image-amd64
+#sudo apt purge linux-image-*-cloud-amd64
+# update-initramfs -u
+# update-grub


### PR DESCRIPTION
we need to switch to a non cloud-init kernel when installing batman-adv from compiled packages