### PR TITLE
Fix: Duplicate keys on disks

### DIFF
--- a/playbooks/roles/ff.wgbroker/templates/broker.py
+++ b/playbooks/roles/ff.wgbroker/templates/broker.py
@@ -5,6 +5,8 @@ import re
 import subprocess
 import unicodedata
 
+from pathlib import Path
+
 from flask import Flask, jsonify, request
 
 
@@ -69,6 +71,20 @@ def precheck(filename, publickey):
         if os.path.isfile(fname):
             raise Exception(f'{filename} already exists')
 
+def remove_existing_key(filename, publickey):
+    for file in Path(REPO).rglob('*'):
+        if file.name == filename:
+            continue
+        if file.is_dir():
+            continue
+        if '.git' in file.relative_to(REPO).parts:
+            continue
+        with file.open('r') as keyonrecord:
+            keyonrecord = keyonrecord.read()
+            if publickey.strip() == keyonrecord.strip():
+                file.unlink()
+                execute_autouser(f"git -C {REPO} add {file}")
+
 def add_file(filename, publickey):
     execute_autouser(f"echo {publickey} > {REPO}/{filename}")
 
@@ -86,6 +102,7 @@ def add_key():
         precheck(filename, data['public_key'])
         execute_autouser(f"git -C {REPO} reset --hard origin/main")
         pull_repo()
+        remove_existing_key(filename, data['public_key'])
         add_file(filename, data['public_key'])
         commit_repo(filename)
         push_repo()


### PR DESCRIPTION
Modify WG-Broker to ensure a changed hostname results in the old host file(s) being removed when the node resubmits their key.

Git commits will thereby reflect "new" keys as renamed files if the key was already present under a different hostname.